### PR TITLE
Fix sidebar backdrop reactivity logic

### DIFF
--- a/src/components/docs/DocsLayout.tsx
+++ b/src/components/docs/DocsLayout.tsx
@@ -95,7 +95,7 @@ export const DocsLayout = define<DocsLayoutProps, DocsLayoutExposed>({
 			}
 		>
 			{computed(() =>
-				(isOpen.value as boolean) ? (
+				isOpen.value ? (
 					<div
 						class="md:hidden fixed inset-0 bg-black/20 z-30 backdrop-blur-sm"
 						onClick={docsStore.toggleSidebar}


### PR DESCRIPTION
This PR fixes the issue where the mobile sidebar backdrop remained visible after closing or navigating. The conditional rendering for the backdrop was not wrapped in computed, causing it to lose reactivity and become stuck in the DOM. This change ensures the backdrop correctly syncs with the sidebar state.